### PR TITLE
Fix truncated integer

### DIFF
--- a/MySensors_Node_Sensor_Dht11.cpp
+++ b/MySensors_Node_Sensor_Dht11.cpp
@@ -18,7 +18,7 @@
 #include "MySensors_Node_Sensor_Dht11.h"
 
 MySensors_Node_Sensor_Dht11::MySensors_Node_Sensor_Dht11( uint8_t temperature_id,
-  uint8_t humidity_id, String description, uint8_t pin, uint16_t interval, int16_t offset )
+  uint8_t humidity_id, String description, uint8_t pin, uint32_t interval, int16_t offset )
   : MySensors_Node_Sensor( temperature_id, S_TEMP, V_TEMP, description ) {
   _humidity_id = humidity_id;
   _pin = pin;

--- a/MySensors_Node_Sensor_Dht11.h
+++ b/MySensors_Node_Sensor_Dht11.h
@@ -30,7 +30,7 @@ class MySensors_Node_Sensor_Dht11 : public MySensors_Node_Sensor {
                                  uint8_t  humidity_id     = 11,
                                  String   description     = "DHT",
                                  uint8_t  pin             = 4,      // Pin for dht11 device
-                                 uint16_t interval        = 120000, // How often to read and send in ms
+                                 uint32_t interval        = 120000, // How often to read and send in ms
                                  int16_t  offset          = 0       // Fixed offset of temperature
                                );
     ~MySensors_Node_Sensor_Dht11();
@@ -44,7 +44,7 @@ class MySensors_Node_Sensor_Dht11 : public MySensors_Node_Sensor {
   private:
     uint8_t  _humidity_id;
     uint8_t  _pin;
-    uint16_t _interval;
+    uint32_t _interval;
     int16_t  _offset;
 
     uint32_t _next_read;


### PR DESCRIPTION
Max value of a uint16_t is 65535 - can't set it to 120000

Fixes this compile error:

In file included from
~\Arduino\libraries\MySensors_Node\MySensors_Node_Sensor_Dht11.cpp:18:0:

~\Arduino\libraries\MySensors_Node\MySensors_Node_Sensor_Dht11.h:33:61:
warning: large integer implicitly truncated to unsigned type
[-Woverflow]

uint16_t interval        = 120000, // How often to read and send in ms